### PR TITLE
Custom Elements and Shadow DOM are landed on Nightly

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 						<td class="yes"><a href="http://w3c.github.io/webcomponents/spec/custom/"></a></td>
 						<td class="yes"><a href="#polyfills"></a></td>
 						<td class="yes"><a href="http://www.chromestatus.com/features/4642138092470272">Stable</a></td>
-						<td class="kinda"><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=856140">Flag</a></td>
+						<td class="yes"><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=856140">Flag</a></td>
 					</tr>s
 					<tr>
 						<th>Shadow DOM</th>
@@ -64,7 +64,7 @@
 						<td class="yes"><a href="http://w3c.github.io/webcomponents/spec/shadow/"></a></td>
 						<td class="yes"><a href="#polyfills"></a></td>
 						<td class="yes"><a href="http://www.chromestatus.com/features/5479141319114752">Stable</a></td>
-						<td class="kinda"><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=806506">Flag</a></td>
+						<td class="yes"><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=806506">Flag</a></td>
 					</tr>
 					<tr class="wait-and-see">
 						<th>Decorators<a href="#fnDecorators"><sup>3</sup></a></th>


### PR DESCRIPTION
According to @csuwildcat:

> Firefox should now show green for Custom Elements and Shadow DOM, both are landed on Nightly and are on the release train.﻿

I'm just not sure if it's under flags or not...
