### PR TITLE
updated Firefox Custom Elements link for unflagging

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
 						<td class="yes"><a href="http://w3c.github.io/webcomponents/spec/custom/"></a></td>
 						<td class="yes"><a href="#polyfills"></a></td>
 						<td class="yes"><a href="http://www.chromestatus.com/features/4642138092470272">Stable</a></td>
-						<td class="yes"><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=856140">Flag</a></td>
+						<td class="yes"><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=889230">Flag</a></td>
 					</tr>
 					<tr>
 						<th>Shadow DOM</th>


### PR DESCRIPTION
This bug seems to have the most current comments on why Custom Elements are still behind a flag.
