### PR TITLE
Update index.html with a section for the new home for polyfills

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,10 +103,10 @@
 					<a href="http://www.w3.org/TR/custom-elements/">Working Draft</a>
 				</li>
 			</ul>
+			
+			<h2 id="libraries">Libraries!</h2>
 
-			<h2 id="polyfills">Polyfills!</h2>
-
-			<p>There are three polyfills of web components available:</p>
+			<p>There are three major libraries for working with and extending web components:</p>
 			
 			<h3><a href="http://x-tags.org/">X-Tags by Mozilla</a></h3>
 
@@ -124,8 +124,12 @@
 			<blockquote>
 				"We loved the Introduction to Web Components spec. What we wanted was a way to build components as this spec describes, shielding ourselves against potential spec changes, and supporting not-so-modern browsers like IE9. And so Bosonic was born!"
 			</blockquote>
-
-			<p>All three libraries share and collaborate upon some libraries that polyfill the main features of web components, such as custom elements and templates, but each builds on them in a unique way. To quote the <a href="http://www.x-tags.org/blog">official X-Tag blog</a>:</p>
+			
+			<h2 id="polyfills">Polyfills!</h2>
+			
+			<p>A set of polyfills for webcomponents and other advanced parts of DOM and JS is now available at <a href="http://webcomponents.org/polyfills/">webcomponents.org</a>.</p>
+			
+			<p>All three libraries share and collaborate upon these polyfills, but each builds on them in a unique way. To quote the <a href="http://www.x-tags.org/blog">official X-Tag blog</a>:</p>
 
 			<blockquote>
 				"X-Tag and Polymer are both high-level sugar libraries that build upon the W3 Web Components specs - each introduces a different approach to making development of web components an even more amazing experience. To help make this more relatable, consider the following: jQuery : DOM :: X-Tag/Polymer : Web Components."


### PR DESCRIPTION
Clarify the distinction between polyfills and libraries even more and provide a link to the new home for the shared polyfills: http://webcomponents.org/polyfills/
