### PR TITLE
The HTML Imports bug is fixed&resolved in Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 						<td class="yes"><a href="http://w3c.github.io/webcomponents/spec/imports/"></a></td>
 						<td class="yes"><a href="#polyfills"></a></td>
 						<td class="yes"><a href="http://www.chromestatus.com/features/5144752345317376">Stable</a></td>
-						<td class="kinda"><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=877072">Flag</a></td>
+						<td class="yes"><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=877072">Flag</a></td>
 					</tr>
 					<tr>
 						<th>Custom Elements</th>


### PR DESCRIPTION
According to Bugzilla and my test run with HTML imports (flags enabled) it is supported (but hidden behind a flag).
