### PR TITLE
Shadow DOM is in Safari 10

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
 						<td class="yes"><a href="#polyfills"></a></td>
 						<td class="yes"><a href="http://www.chromestatus.com/features/4507242028072960">Stable</a></td>
 						<td class="yes"><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=806506">Flag</a></td>
-						<td class="kinda"><a href="https://bugs.webkit.org/show_bug.cgi?id=148695">WebKit Nightly</a></td>
+						<td class="kinda"><a href="https://developer.apple.com/library/prerelease/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_10_0.html">10</a></td>
 						<td class="vote"><a href="https://wpdev.uservoice.com/forums/257854-internet-explorer-platform/suggestions/6263785-shadow-dom-unprefixed">Vote</a></td>
 					</tr>
 				</tbody>


### PR DESCRIPTION
The Safari 10.0 docs mention Shadow DOM support :-)
